### PR TITLE
Add GitHub Sponsors funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: timbrigham


### PR DESCRIPTION
## Summary

- Adds `.github/FUNDING.yml` to enable the GitHub Sponsors button on the repository page
- Configured for GitHub user `timbrigham`

## Notes

The Sponsor button will appear on the repo page once the account is enrolled at github.com/sponsors. No other files are changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
