### PR TITLE
docs(Basic.lean): add module docstring orienting library readers

### DIFF
--- a/ZeroParadox/Basic.lean
+++ b/ZeroParadox/Basic.lean
@@ -8,3 +8,21 @@ import ZeroParadox.ZPH
 import ZeroParadox.ZPI
 import ZeroParadox.ZPJ
 import ZeroParadox.ZPK
+
+/-!
+# Zero Paradox — Library Root
+
+Umbrella import for the full Zero Paradox Lean library. Importing this single file
+pulls in all formalized layers (ZP-A through ZP-K). For per-file summaries, dependency
+order, axiom profile, and honest scope boundaries, see `ZeroParadox/README.md`.
+
+Dependency order of the layers:
+
+  ZP-A → ZP-B → ZP-C → ZP-D → ZP-E → ZP-J → ZP-K → ZP-I
+
+  ZP-G (self-contained) → ZP-H (depends on ZP-G, ZP-C, ZP-D)
+
+The central result is **T-SNAP** (`ZeroParadox.ZPE.t_snap_machine` and
+`ZeroParadox.ZPE.t_snap_derived`): the Binary Snap c₀ ∨ c₁ = c₁ — derived from the
+standard join-semilattice bottom axiom A4, with no snap-specific commitments.
+-/

--- a/ZeroParadox/README.md
+++ b/ZeroParadox/README.md
@@ -1,5 +1,7 @@
 # Zero Paradox — Lean 4 Source
 
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml)
+
 Lean 4 + Mathlib proofs for the Zero Paradox framework. The central result is **T-SNAP** (Binary Snap: `join c₀ c₁ = c₁`), derived from standard join-semilattice axioms. For full project context see [README.md](../README.md) at the repository root.
 
 ## Build


### PR DESCRIPTION
## Summary

- Adds a module docstring to `ZeroParadox/Basic.lean`, which was previously eleven lines of imports with no context.
- Names the file as the library umbrella import, points readers to `ZeroParadox/README.md` for per-file detail, summarises the layer dependency order, and identifies T-SNAP as the central result.
- Prepares the Lean source for first-time readers arriving from the Lean Zulip community without the surrounding PDFs.

Pure docstring change — cannot affect the build. Lean Action CI will verify on this PR.

## Test plan

- [ ] Lean Action CI passes (`lake build` clean)
- [ ] `Basic.lean` renders correctly when viewed on GitHub

https://claude.ai/code/session_0189Dwf2uSyfouAAjDAnJz6y

---
_Generated by [Claude Code](https://claude.ai/code/session_0189Dwf2uSyfouAAjDAnJz6y)_