### PR TITLE
docs(lean): engineer's take first pass — all ZP modules

### DIFF
--- a/ZeroParadox/ZPA.lean
+++ b/ZeroParadox/ZPA.lean
@@ -19,6 +19,8 @@ derives it from structure.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Formalizes the Zero Paradox join-semilattice with bottom (L, ∨, ⊥).
 Axioms A1–A4, definitions D1–D3, and theorems T1–T3 are proved directly
 from the axioms. CC-1 is stated as a conditional claim.

--- a/ZeroParadox/ZPA.lean
+++ b/ZeroParadox/ZPA.lean
@@ -3,6 +3,20 @@ import Mathlib.Tactic
 /-!
 # ZP-A: Lattice Algebra
 
+## Engineer's Take
+
+When you join bottom to itself, it doesn't change. Anytime you join zero to
+something above it, it likewise doesn't change. Joining anything to itself
+returns you back to the same thing. You get the partial order from A1, A2,
+and A3, which we can leverage later. Bottom isn't algebraic zero. It's the
+bottom of a series of actions, the null state, where nothing has occurred yet.
+D2 says that states always have to grow. If you take the null action you stay
+where you are. Any other action moves you forward. Bottom is literally the
+bottom value. Start at null, take any non-null action, and you cannot get back
+to it. At this level it looks like a modeling choice. It's not something the
+algebra forces here. Bottom is where we define the starting point to be. ZPJ
+derives it from structure.
+
 Formalizes the Zero Paradox join-semilattice with bottom (L, ∨, ⊥).
 Axioms A1–A4, definitions D1–D3, and theorems T1–T3 are proved directly
 from the axioms. CC-1 is stated as a conditional claim.

--- a/ZeroParadox/ZPA.lean
+++ b/ZeroParadox/ZPA.lean
@@ -17,6 +17,8 @@ to it. At this level it looks like a modeling choice. It's not something the
 algebra forces here. Bottom is where we define the starting point to be. ZPJ
 derives it from structure.
 
+---
+
 Formalizes the Zero Paradox join-semilattice with bottom (L, ∨, ⊥).
 Axioms A1–A4, definitions D1–D3, and theorems T1–T3 are proved directly
 from the axioms. CC-1 is stated as a conditional claim.

--- a/ZeroParadox/ZPB.lean
+++ b/ZeroParadox/ZPB.lean
@@ -8,6 +8,17 @@ import Mathlib.Tactic
 /-!
 # ZP-B: p-Adic Topology
 
+## Engineer's Take
+
+The states that we defined in ZPA either exist or they don't. There's no in
+between or half existing. This models that logic. In order to model a binary
+state two is the minimum number of states required. Anything else will
+eventually reduce down to one of the two. The transitive relationship for
+closeness doesn't degrade because of the triangle inequality. The balls behave
+like a step function. You're in or you're out. There's a hard gap between the
+two sides and no way to approach the boundary from either direction. C3 follows
+from the totally disconnected structure of Q₂.
+
 Formalizes the Zero Paradox p-adic framework over Q₂ (the 2-adic rationals).
 Proves: ultrametric T1, clopen balls T2, topological isolation T3,
 total disconnectedness T5, and irreversibility of the Snap C3.

--- a/ZeroParadox/ZPB.lean
+++ b/ZeroParadox/ZPB.lean
@@ -19,6 +19,8 @@ like a step function. You're in or you're out. There's a hard gap between the
 two sides and no way to approach the boundary from either direction. C3 follows
 from the totally disconnected structure of Q₂.
 
+---
+
 Formalizes the Zero Paradox p-adic framework over Q₂ (the 2-adic rationals).
 Proves: ultrametric T1, clopen balls T2, topological isolation T3,
 total disconnectedness T5, and irreversibility of the Snap C3.

--- a/ZeroParadox/ZPB.lean
+++ b/ZeroParadox/ZPB.lean
@@ -21,6 +21,8 @@ from the totally disconnected structure of Q₂.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Formalizes the Zero Paradox p-adic framework over Q₂ (the 2-adic rationals).
 Proves: ultrametric T1, clopen balls T2, topological isolation T3,
 total disconnectedness T5, and irreversibility of the Snap C3.

--- a/ZeroParadox/ZPC.lean
+++ b/ZeroParadox/ZPC.lean
@@ -8,6 +8,24 @@ import Mathlib.Tactic
 /-!
 # ZP-C: Information Theory
 
+## Engineer's Take
+
+ZPC doesn't build on ZPA or ZPB. It just follows the same conceptual ground.
+Each state can be represented by a distribution of probability. All probability
+exists either on null or all on the first state, where all mass exists. We're
+then looking at the way that the distribution between the two of them lays out
+mathematically. Specifically, this comes back to log two or exactly one bit,
+which is the information distance between existence and nonexistence. The deeper
+that you go requires more information. Just like you would in computer
+programming. You need n bits to describe your position if you're n steps away.
+The null state is the limit in the hierarchy. Basically infinite depth. The
+surprisal isn't finite. You cannot describe it with any fixed number of bits.
+There's no finite external description. No limited number of entries covers an
+infinite value. L-RUN and TQ-IH look at this like a machine. An initial
+configuration and when it's running. Crossing from the initial to the running is
+a state change in and of itself. It's a non-null value. You cannot execute
+without that crossing having occurred.
+
 Formalizes the Zero Paradox information-theoretic framework over binary
 ontological states. Proves: T1 (unique state distributions), T1b (JSD = log 2),
 D5 (DF antisymmetry), T2 (non-conservative circulation), L-RUN (execution is

--- a/ZeroParadox/ZPC.lean
+++ b/ZeroParadox/ZPC.lean
@@ -28,6 +28,8 @@ without that crossing having occurred.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Formalizes the Zero Paradox information-theoretic framework over binary
 ontological states. Proves: T1 (unique state distributions), T1b (JSD = log 2),
 D5 (DF antisymmetry), T2 (non-conservative circulation), L-RUN (execution is

--- a/ZeroParadox/ZPC.lean
+++ b/ZeroParadox/ZPC.lean
@@ -26,6 +26,8 @@ configuration and when it's running. Crossing from the initial to the running is
 a state change in and of itself. It's a non-null value. You cannot execute
 without that crossing having occurred.
 
+---
+
 Formalizes the Zero Paradox information-theoretic framework over binary
 ontological states. Proves: T1 (unique state distributions), T1b (JSD = log 2),
 D5 (DF antisymmetry), T2 (non-conservative circulation), L-RUN (execution is

--- a/ZeroParadox/ZPD.lean
+++ b/ZeroParadox/ZPD.lean
@@ -5,6 +5,20 @@ import Mathlib.Tactic
 /-!
 # ZP-D: State Layer (Hilbert Space)
 
+## Engineer's Take
+
+This file builds on the Q₂ ball structure and represents the balls as vectors.
+We use DP-1 to make sure we're mapping from Q₂ into H while faithfully
+representing the Q₂ ball structure. The disjointness lives in Q₂. Orthogonality
+preserves that property inside H. That's a design choice. It's not forced, but
+if you don't make it you're no longer faithfully representing the topology. T2
+keeps the balls unique. Every vector comes out the same length, just orthogonal
+to each other. That makes this a valid representation rather than just any
+generic map. There's essentially one way to lay this out. Because of how it
+lands on orthogonal axes, they're going completely separate directions. The snap
+from null to ε₀ is the payoff. Before and after point in completely orthogonal
+directions inside H.
+
 Formalizes the Zero Paradox Hilbert space state layer H = ℂⁿ and the
 transition operator T: Q₂ → H. Q₂'s clopen-ball partition is abstracted
 as `Fin n`, keeping this file self-contained within functional analysis

--- a/ZeroParadox/ZPD.lean
+++ b/ZeroParadox/ZPD.lean
@@ -21,6 +21,8 @@ directions inside H.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Formalizes the Zero Paradox Hilbert space state layer H = ℂⁿ and the
 transition operator T: Q₂ → H. Q₂'s clopen-ball partition is abstracted
 as `Fin n`, keeping this file self-contained within functional analysis

--- a/ZeroParadox/ZPD.lean
+++ b/ZeroParadox/ZPD.lean
@@ -19,6 +19,8 @@ lands on orthogonal axes, they're going completely separate directions. The snap
 from null to ε₀ is the payoff. Before and after point in completely orthogonal
 directions inside H.
 
+---
+
 Formalizes the Zero Paradox Hilbert space state layer H = ℂⁿ and the
 transition operator T: Q₂ → H. Q₂'s clopen-ball partition is abstracted
 as `Fin n`, keeping this file self-contained within functional analysis

--- a/ZeroParadox/ZPE.lean
+++ b/ZeroParadox/ZPE.lean
@@ -19,6 +19,8 @@ DA-1 is addressed in ZPJ and ZPK. DA-2 is addressed in ZPI.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Cross-framework synthesis of ZP-A through ZP-D. Provides three formal inserts:
 
 - DA-1 (Instantiation as Execution): Paths 1 and 3 are now in Lean scope via ZP-K.

--- a/ZeroParadox/ZPE.lean
+++ b/ZeroParadox/ZPE.lean
@@ -17,6 +17,8 @@ that it executed at one point in the past. DA-1, DA-2, and DA-3 need to be
 treated as forward references. These were not solved until a much later point.
 DA-1 is addressed in ZPJ and ZPK. DA-2 is addressed in ZPI.
 
+---
+
 Cross-framework synthesis of ZP-A through ZP-D. Provides three formal inserts:
 
 - DA-1 (Instantiation as Execution): Paths 1 and 3 are now in Lean scope via ZP-K.

--- a/ZeroParadox/ZPE.lean
+++ b/ZeroParadox/ZPE.lean
@@ -7,6 +7,16 @@ import Mathlib.Tactic
 /-!
 # ZP-E: Bridge Document
 
+## Engineer's Take
+
+By wiring together the state changes out of ZPC and the mandatory increments in
+ZPA, it turned AX-1 into a theorem we can prove instead of an axiom. In
+programming you can have a state change eventually return to non-running.
+However, once a program is executed, it's executed. It doesn't change the fact
+that it executed at one point in the past. DA-1, DA-2, and DA-3 need to be
+treated as forward references. These were not solved until a much later point.
+DA-1 is addressed in ZPJ and ZPK. DA-2 is addressed in ZPI.
+
 Cross-framework synthesis of ZP-A through ZP-D. Provides three formal inserts:
 
 - DA-1 (Instantiation as Execution): Paths 1 and 3 are now in Lean scope via ZP-K.

--- a/ZeroParadox/ZPG.lean
+++ b/ZeroParadox/ZPG.lean
@@ -17,6 +17,8 @@ structure. The one-directionness itself is precisely why you can't return to
 the initial state. Zero is simultaneously the universal source and the one
 thing you can never get back to.
 
+---
+
 Formal verification of ZP-G v1.1 (Category Theory layer).
 Self-contained in category theory with one named import (I-KC, Kolmogorov complexity).
 

--- a/ZeroParadox/ZPG.lean
+++ b/ZeroParadox/ZPG.lean
@@ -6,6 +6,17 @@ import Mathlib.Tactic
 /-!
 # ZP-G: Category Theory
 
+## Engineer's Take
+
+In category theory terms, this is essentially the most abstract form of a
+directed graph. Objects are nodes. Morphisms are directed edges. Zero is the
+initial object. It has exactly one outbound edge to every other node in the
+graph. It has no inbound edges from anything outside itself. Both of those
+are structural axioms, not consequences. The paradox comes from being a step
+structure. The one-directionness itself is precisely why you can't return to
+the initial state. Zero is simultaneously the universal source and the one
+thing you can never get back to.
+
 Formal verification of ZP-G v1.1 (Category Theory layer).
 Self-contained in category theory with one named import (I-KC, Kolmogorov complexity).
 

--- a/ZeroParadox/ZPG.lean
+++ b/ZeroParadox/ZPG.lean
@@ -19,6 +19,8 @@ thing you can never get back to.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Formal verification of ZP-G v1.1 (Category Theory layer).
 Self-contained in category theory with one named import (I-KC, Kolmogorov complexity).
 

--- a/ZeroParadox/ZPH.lean
+++ b/ZeroParadox/ZPH.lean
@@ -9,6 +9,15 @@ import Mathlib.Tactic
 /-!
 # ZP-H: Categorical Bridge
 
+## Engineer's Take
+
+Now that the categorical structure is established, ZPH goes back through ZPA
+to ZPD and shows that each of those frameworks is a representation of the same
+underlying object. The algebra, the topology, the information theory, and the
+Hilbert space are not four separate things. They are different vantage points
+on the same object. T-H3 is the formal statement of that. Four independent
+derivations, same snap, same verdict.
+
 Connects ZP-G (Category Theory) to ZP-A through ZP-E. Every cross-framework claim
 is traced to a theorem in ZP-G or ZP-A through ZP-E, plus an explicit bridge axiom
 where required. No floating connections.

--- a/ZeroParadox/ZPH.lean
+++ b/ZeroParadox/ZPH.lean
@@ -18,6 +18,8 @@ Hilbert space are not four separate things. They are different vantage points
 on the same object. T-H3 is the formal statement of that. Four independent
 derivations, same snap, same verdict.
 
+---
+
 Connects ZP-G (Category Theory) to ZP-A through ZP-E. Every cross-framework claim
 is traced to a theorem in ZP-G or ZP-A through ZP-E, plus an explicit bridge axiom
 where required. No floating connections.

--- a/ZeroParadox/ZPH.lean
+++ b/ZeroParadox/ZPH.lean
@@ -20,6 +20,8 @@ derivations, same snap, same verdict.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Connects ZP-G (Category Theory) to ZP-A through ZP-E. Every cross-framework claim
 is traced to a theorem in ZP-G or ZP-A through ZP-E, plus an explicit bridge axiom
 where required. No floating connections.

--- a/ZeroParadox/ZPI.lean
+++ b/ZeroParadox/ZPI.lean
@@ -6,6 +6,16 @@ import Mathlib.Tactic
 /-!
 # ZP-I: Inside Zero
 
+## Engineer's Take
+
+Everything up to this point has been from the perspective of one bottom reaching
+upward. Because there is no top element, the chain cannot stop. In the 2-adic
+metric, going higher in the lattice means getting closer to zero. The chain
+approaches zero not by reversing but by continuing forward. When the action of
+reaching that limit has occurred, you are transitioning to the next bottom, along
+the next axis. Bottom n goes to bottom n+1, ad infinitum. T-IZ is the formal
+proof that this transition is not assumed. It is derived.
+
 Theorem T-IZ: Every maximal ascending chain in the Zero Paradox framework is a
 Cauchy sequence that converges to its own successor null in the 2-adic metric.
 

--- a/ZeroParadox/ZPI.lean
+++ b/ZeroParadox/ZPI.lean
@@ -16,6 +16,8 @@ reaching that limit has occurred, you are transitioning to the next bottom, alon
 the next axis. Bottom n goes to bottom n+1, ad infinitum. T-IZ is the formal
 proof that this transition is not assumed. It is derived.
 
+---
+
 Theorem T-IZ: Every maximal ascending chain in the Zero Paradox framework is a
 Cauchy sequence that converges to its own successor null in the 2-adic metric.
 

--- a/ZeroParadox/ZPI.lean
+++ b/ZeroParadox/ZPI.lean
@@ -18,6 +18,8 @@ proof that this transition is not assumed. It is derived.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Theorem T-IZ: Every maximal ascending chain in the Zero Paradox framework is a
 Cauchy sequence that converges to its own successor null in the 2-adic metric.
 

--- a/ZeroParadox/ZPJ.lean
+++ b/ZeroParadox/ZPJ.lean
@@ -4,6 +4,19 @@ import Mathlib.Tactic
 /-!
 # ZP-J: Executability of Self-Reference
 
+## Engineer's Take
+
+Bottom is self-containing. It is the only element inside of Q. Quine uniqueness
+means there can only be one such element, and it is bottom. There is nothing
+outside of bottom because bottom is the starting point. There is no prior state.
+If bottom is going to do anything, the only thing that can do it is itself.
+Self-contained plus forced execution means bottom is effectively its own program.
+Much like a bootstrapping C compiler. The language could expand to future states,
+but at some point it needed to understand enough about itself to perform the
+bootstrapping. There is no prior version to fall back on. ZPK extends this to
+the computational setting. The question of whether there are infinitely many
+such bottom elements across instantiations is addressed in ZPI.
+
 Establishes T-EXEC: in any ZP-A lattice with AFA set-theoretic grounding, the
 unique Quine atom Q (satisfying Q = {Q} under AFA) is provably the bottom element
 ⊥ — deriving CC-1 from ZP-A rather than committing to it.

--- a/ZeroParadox/ZPJ.lean
+++ b/ZeroParadox/ZPJ.lean
@@ -19,6 +19,8 @@ such bottom elements across instantiations is addressed in ZPI.
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Establishes T-EXEC: in any ZP-A lattice with AFA set-theoretic grounding, the
 unique Quine atom Q (satisfying Q = {Q} under AFA) is provably the bottom element
 ⊥ — deriving CC-1 from ZP-A rather than committing to it.

--- a/ZeroParadox/ZPJ.lean
+++ b/ZeroParadox/ZPJ.lean
@@ -17,6 +17,8 @@ bootstrapping. There is no prior version to fall back on. ZPK extends this to
 the computational setting. The question of whether there are infinitely many
 such bottom elements across instantiations is addressed in ZPI.
 
+---
+
 Establishes T-EXEC: in any ZP-A lattice with AFA set-theoretic grounding, the
 unique Quine atom Q (satisfying Q = {Q} under AFA) is provably the bottom element
 ⊥ — deriving CC-1 from ZP-A rather than committing to it.

--- a/ZeroParadox/ZPK.lean
+++ b/ZeroParadox/ZPK.lean
@@ -20,6 +20,8 @@ equivalence. Being bottom, being the Quine atom, satisfying the join identity,
 and being a Kleene fixed point are all the same structural fact stated in four
 different formal languages. DA-1 Paths 1 and 3 were always naming the same thing.
 
+---
+
 Establishes the four-way equivalence between the structural roles of ⊥:
 
   (1) Quine atom       — set-theoretic self-reference (ZF + AFA)

--- a/ZeroParadox/ZPK.lean
+++ b/ZeroParadox/ZPK.lean
@@ -22,6 +22,8 @@ different formal languages. DA-1 Paths 1 and 3 were always naming the same thing
 
 ---
 
+## Formal Overview (AI-assisted)
+
 Establishes the four-way equivalence between the structural roles of ⊥:
 
   (1) Quine atom       — set-theoretic self-reference (ZF + AFA)

--- a/ZeroParadox/ZPK.lean
+++ b/ZeroParadox/ZPK.lean
@@ -6,6 +6,20 @@ import Mathlib.Tactic
 /-!
 # ZP-K: Computational Grounding of Self-Reference
 
+## Engineer's Take
+
+ZPJ established the set-theoretic case. ZPK adds the computational grounding.
+Existence is itself an action away from null. Action by definition is not null.
+There is nothing prior to bottom that could trigger it. So if bottom is going
+to do anything, it has to do it itself. Kleene's theorem is basically saying
+that there is always a version of that logic. It isn't specific to one
+programming language or way of looking at things. Much like the bootstrapping
+problem in any sufficiently powerful language. It is not specific to one system.
+Any language powerful enough eventually has to face it. T-COMP is the four-way
+equivalence. Being bottom, being the Quine atom, satisfying the join identity,
+and being a Kleene fixed point are all the same structural fact stated in four
+different formal languages. DA-1 Paths 1 and 3 were always naming the same thing.
+
 Establishes the four-way equivalence between the structural roles of ⊥:
 
   (1) Quine atom       — set-theoretic self-reference (ZF + AFA)


### PR DESCRIPTION
## Summary

- Add `## Engineer's Take` blocks to all ten ZP Lean modules (ZPA through ZPI, including ZPG and ZPH)
- First pass complete: one paragraph per file, oriented toward engineers and programmers
- No formal mathematical content changed — additions are purely docstring commentary

## What this is

The existing Lean docstrings target mathematicians who already know the field. This PR adds an engineer's-take layer to make the work approachable to software people who can read code but aren't deep mathematicians — mirroring how the framework was actually built.

Each block is written in Tim's voice through a tutor process: Claude explains, Tim talks back what he understood, Claude transcribes Tim's phrasing preserving rhythm and idiom. The prose is intentionally not AI-shaped.

## Files changed

- `ZPA.lean` — lattice algebra, partial order, bottom as null state
- `ZPB.lean` — binary states, p-adic ultrametric, step function balls
- `ZPC.lean` — probability distributions, 1-bit JSD, surprisal field, L-RUN/TQ-IH
- `ZPD.lean` — Q₂ ball structure as vectors, DP-1 design choice, orthogonal snap
- `ZPE.lean` — T-SNAP derived (not axiom), forward references to ZPJ/ZPK/ZPI
- `ZPG.lean` — category theory as directed graph, T7 paradox
- `ZPH.lean` — four frameworks as vantage points on same object, T-H3
- `ZPJ.lean` — AFA self-containment, bootstrapping C compiler analogy, forward ref to ZPK/ZPI
- `ZPK.lean` — Kleene fixed point, T-COMP four-way equivalence, DA-1 closure
- `ZPI.lean` — T-IZ, bottom n to bottom n+1 ad infinitum

## Build status

Zero errors, zero warnings. 3326 jobs clean.
