### PR TITLE
feat: add .zenodo.json for automated DOI snapshots

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,9 +1,9 @@
 {
   "title": "The Zero Paradox: A Multi-Framework Mathematical Ontology",
-  "description": "A formal mathematical ontology proving the Binary Snap as a theorem across lattice algebra, p-adic topology, information theory, functional analysis, and category theory. The central result — that a specific state transition from null to first determinate state is structurally forced by standard mathematical commitments — is derived across five formal layers (ZP-A through ZP-E) and extended categorically (ZP-G, ZP-H). All core theorems are verified sorry-free in Lean 4 + Mathlib.",
+  "description": "A formal mathematical ontology proving the Binary Snap as a theorem across lattice algebra, p-adic topology, information theory, functional analysis, and category theory. The central result — that a specific state transition from null to first determinate state is structurally forced by standard mathematical commitments — is derived across ten formal layers (ZP-A through ZP-K, excluding ZP-F) and verified sorry-free in Lean 4 + Mathlib. Layers include: ZP-A (lattice algebra), ZP-B (p-adic topology), ZP-C (information theory), ZP-D (functional analysis), ZP-E (cross-framework synthesis), ZP-G (category theory), ZP-H (categorical bridge), ZP-I (inside zero), ZP-J (self-reference), ZP-K (computational grounding).",
   "creators": [
     {
-      "name": "Brigham, Tim"
+      "name": "Brigham, Timothy"
     }
   ],
   "license": "cc-by-nc-nd-4.0",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,25 @@
+{
+  "title": "The Zero Paradox: A Multi-Framework Mathematical Ontology",
+  "description": "A formal mathematical ontology proving the Binary Snap as a theorem across lattice algebra, p-adic topology, information theory, functional analysis, and category theory. The central result — that a specific state transition from null to first determinate state is structurally forced by standard mathematical commitments — is derived across five formal layers (ZP-A through ZP-E) and extended categorically (ZP-G, ZP-H). All core theorems are verified sorry-free in Lean 4 + Mathlib.",
+  "creators": [
+    {
+      "name": "Brigham, Tim"
+    }
+  ],
+  "license": "cc-by-nc-nd-4.0",
+  "keywords": [
+    "mathematical ontology",
+    "lattice algebra",
+    "p-adic topology",
+    "information theory",
+    "category theory",
+    "Lean 4",
+    "formal verification",
+    "foundational mathematics",
+    "binary snap",
+    "join-semilattice"
+  ],
+  "upload_type": "publication",
+  "publication_type": "workingpaper",
+  "access_right": "open"
+}


### PR DESCRIPTION
## Summary

Adds `.zenodo.json` to enable automated DOI snapshots via Zenodo on every GitHub release.

**What this does:**
- Zenodo watches the repo (already authorized) and fires automatically on each GitHub Release
- Each release gets a permanent DOI and is publicly citable
- A "concept DOI" will always point to the latest version
- Full version history is preserved and linked under the concept DOI
- CC BY-NC-ND 4.0 license declared; upload type is working paper

**What happens next:**
1. Merge this PR to main
2. Create a GitHub Release (any tag, e.g. `v1.0`)
3. Zenodo fires automatically and assigns a DOI
4. Grab the badge snippet from Zenodo and add to README.md in a follow-up commit

## What did not change

No mathematical content, PDFs, or Lean proofs were modified.

Generated with Claude Code
