### PR TITLE
feat: RELEASES.md and release workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,52 @@ Transparency is a core value of this project. The existence of this private fold
 - The `historical/README.md` tracks all archived files with date moved and description
 - README.md always links to the non-suffixed (current) version
 
+## GitHub Releases and Zenodo Snapshots
+
+GitHub Releases trigger automatic Zenodo snapshots with permanent DOIs. `RELEASES.md` is the human-readable record of each release.
+
+### Release naming
+
+`v<major>.<minor>` — e.g. `v1.0`, `v1.1`, `v2.0`
+
+### What triggers a release
+
+- **Major version** (`v1.0 → v2.0`): a new formal layer added, or a theorem status changes (candidate → derived), or a significant structural revision to the framework
+- **Minor version** (`v1.0 → v1.1`): a substantive reviewer feedback round addressed, or accumulated document/companion updates that represent a meaningful state of the framework
+
+**Do not release on:** every individual PR. Releases should feel like milestones worth timestamping.
+
+### Release workflow
+
+1. Update `RELEASES.md` with the new version entry (version, date, why, what's included, document versions, next threshold)
+2. Commit and merge to main via PR
+3. Draft the GitHub Release body (Claude drafts this — see below)
+4. Tim creates the GitHub Release with the drafted body — Zenodo fires automatically
+5. Grab the Zenodo DOI badge and add to README.md in a follow-up commit
+
+### Claude's role in drafting releases
+
+When Tim says it's time for a release, Claude will:
+1. Read `RELEASES.md` and the merged PR history since the last release
+2. Draft the `RELEASES.md` entry for the new version
+3. Draft the full GitHub Release body (title, description, changelog) ready to paste into GitHub
+4. Open a PR with the `RELEASES.md` update
+5. After merge, provide the exact GitHub Release body for Tim to paste
+
+### RELEASES.md entry format
+
+```
+## vX.Y — YYYY-MM-DD
+
+**Why this release:** [one sentence — what milestone this represents]
+
+**What changed:** [bullet list of significant changes since last release]
+
+**Document versions at this release:** [table — only documents that changed since last release, or full table for major versions]
+
+**Next threshold:** [what would trigger v(X.Y+1) vs v(X+1.0)]
+```
+
 ## register.md — Canonical Version Registry
 
 `register.md` is the authoritative source for all current document version numbers, filenames, and companion versions. It is committed to the public repository but intentionally unlinked from both README.md and GUIDE.md (and carries a transparency notice per the Transparency Notices policy).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ GitHub Releases trigger automatic Zenodo snapshots with permanent DOIs. `RELEASE
 
 ### Release naming
 
-`v<major>.<minor>` — e.g. `v1.0`, `v1.1`, `v2.0`
+`v<major>.<minor>` - e.g. `v1.0`, `v1.1`, `v2.0`
 
 ### What triggers a release
 
@@ -54,8 +54,8 @@ GitHub Releases trigger automatic Zenodo snapshots with permanent DOIs. `RELEASE
 
 1. Update `RELEASES.md` with the new version entry (version, date, why, what's included, document versions, next threshold)
 2. Commit and merge to main via PR
-3. Draft the GitHub Release body (Claude drafts this — see below)
-4. Tim creates the GitHub Release with the drafted body — Zenodo fires automatically
+3. Draft the GitHub Release body (Claude drafts this - see below)
+4. Tim creates the GitHub Release with the drafted body - Zenodo fires automatically
 5. Grab the Zenodo DOI badge and add to README.md in a follow-up commit
 
 ### Claude's role in drafting releases
@@ -70,13 +70,13 @@ When Tim says it's time for a release, Claude will:
 ### RELEASES.md entry format
 
 ```
-## vX.Y — YYYY-MM-DD
+## vX.Y - YYYY-MM-DD
 
-**Why this release:** [one sentence — what milestone this represents]
+**Why this release:** [one sentence - what milestone this represents]
 
 **What changed:** [bullet list of significant changes since last release]
 
-**Document versions at this release:** [table — only documents that changed since last release, or full table for major versions]
+**Document versions at this release:** [table - only documents that changed since last release, or full table for major versions]
 
 **Next threshold:** [what would trigger v(X.Y+1) vs v(X+1.0)]
 ```

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,12 +1,12 @@
 > **A note on transparency:** This file lives in the public repository but is intentionally unlinked from the main project index. It is the release history for GitHub releases and Zenodo snapshots. The main entry point for the Zero Paradox is [README.md](README.md).
 
-# Zero Paradox — Release History
+# Zero Paradox - Release History
 
 Each GitHub release triggers an automatic Zenodo snapshot with a permanent DOI. This file is the human-readable record of what warranted each release and what the next threshold is.
 
 ---
 
-## v1.0 — 2026-05-07
+## v1.0 - 2026-05-07
 
 **Why this release:** First public Zenodo snapshot. The framework is complete across ten formal layers with all core theorems verified sorry-free in Lean 4 + Mathlib. Zenodo integration established via `.zenodo.json`.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,33 @@
+> **A note on transparency:** This file lives in the public repository but is intentionally unlinked from the main project index. It is the release history for GitHub releases and Zenodo snapshots. The main entry point for the Zero Paradox is [README.md](README.md).
+
+# Zero Paradox — Release History
+
+Each GitHub release triggers an automatic Zenodo snapshot with a permanent DOI. This file is the human-readable record of what warranted each release and what the next threshold is.
+
+---
+
+## v1.0 — 2026-05-07
+
+**Why this release:** First public Zenodo snapshot. The framework is complete across ten formal layers with all core theorems verified sorry-free in Lean 4 + Mathlib. Zenodo integration established via `.zenodo.json`.
+
+**What is included:**
+- ZP-A through ZP-K (ten layers; ZP-F intentionally skipped)
+- All formal PDFs and illustrated companions
+- Lean 4 source with clean build (no sorries)
+- Full scripts/ transparency copy of PDF build tooling
+
+**Document versions at this release:**
+| Document | Version |
+|----------|---------|
+| ZP-A Lattice Algebra | v1.13 |
+| ZP-B p-Adic Topology | v1.6 |
+| ZP-C Information Theory | v1.12 |
+| ZP-D State Layer | v1.8 |
+| ZP-E Bridge Document | v3.12 |
+| ZP-G Category Theory | v1.7 |
+| ZP-H Categorical Bridge | v1.11 |
+| ZP-I Inside Zero | v1.8 |
+| ZP-J Self-Reference | v1.1 |
+| ZP-K Computational Grounding | v1.3 |
+
+**Next threshold:** v1.1 on first substantive reviewer feedback round; v2.0 if a new formal layer is added or a major theorem status changes.


### PR DESCRIPTION
## Summary

Adds release infrastructure: `RELEASES.md` for tracking GitHub/Zenodo release history, and release workflow rules in `CLAUDE.md`.

**RELEASES.md:**
- New public file — human-readable record of each GitHub release
- v1.0 entry documents the first Zenodo snapshot: ten formal layers, clean Lean build, document versions at release, next threshold
- Carries transparency notice (unlinked from main index)

**CLAUDE.md — GitHub Releases and Zenodo Snapshots section:**
- Release naming convention (v<major>.<minor>)
- Rules for what triggers major vs minor release
- Release workflow (RELEASES.md update → PR → GitHub Release → Zenodo fires → badge)
- Claude's drafting role defined
- RELEASES.md entry format documented

## What did not change

No mathematical content, PDFs, or Lean proofs were modified.

## Test plan

- [x] Pre-push hook passed
- [x] RELEASES.md carries transparency notice per policy
- [x] RELEASES.md intentionally unlinked from README.md and GUIDE.md

Generated with Claude Code
