### PR TITLE
feat: Zenodo DOI badge and release approval workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,6 +435,11 @@ All work — Lean 4 proofs and PDF rendering — happens on the `illustrated` br
    gh pr create --title "..." --body-file ".claude-local\pr_body_<name>.md"
    ```
 
+8. **Keep PR description current:** If additional commits are pushed to a branch after the PR is opened, update the PR body to reflect the new content. Update `.claude-local\pr_body_<name>.md` first, then run:
+   ```powershell
+   gh pr edit <number> --body-file ".claude-local\pr_body_<name>.md"
+   ```
+
 ## File Priority
 - Both `.lean` files and PDF build scripts are first-class on `illustrated`.
 - All other conventions (versioning, archiving, scripts/ sync) apply as documented above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ GitHub Releases trigger automatic Zenodo snapshots with permanent DOIs. `RELEASE
 1. Update `RELEASES.md` with the new version entry (version, date, why, what's included, document versions, next threshold)
 2. Commit and merge to main via PR
 3. Draft the GitHub Release body and present it to Tim for approval
-4. On explicit approval, execute `gh release create` directly - do not ask Tim to do it manually
+4. On explicit approval, execute `gh release create <tag> --target main --title "<tag> - <title>" --notes-file ".claude-local\release_<tag>_body.md"` directly - do not ask Tim to do it manually
 5. Grab the Zenodo DOI badge and add to README.md in a follow-up commit
 
 ### Claude's role in drafting releases
@@ -66,7 +66,7 @@ When Tim says it's time for a release, Claude will:
 3. Open a PR with the `RELEASES.md` update
 4. After merge, draft the full GitHub Release body and present it to Tim
 5. **Wait for explicit approval before executing** - do not run `gh release create` until Tim confirms the language
-6. On approval, run `gh release create` with `--notes-file` automatically - no further prompting needed
+6. On approval, run `gh release create <tag> --target main --title "<tag> - <title>" --notes-file ".claude-local\release_<tag>_body.md"` - no further prompting needed
 
 ### RELEASES.md entry format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,8 @@ GitHub Releases trigger automatic Zenodo snapshots with permanent DOIs. `RELEASE
 
 1. Update `RELEASES.md` with the new version entry (version, date, why, what's included, document versions, next threshold)
 2. Commit and merge to main via PR
-3. Draft the GitHub Release body (Claude drafts this - see below)
-4. Tim creates the GitHub Release with the drafted body - Zenodo fires automatically
+3. Draft the GitHub Release body and present it to Tim for approval
+4. On explicit approval, execute `gh release create` directly - do not ask Tim to do it manually
 5. Grab the Zenodo DOI badge and add to README.md in a follow-up commit
 
 ### Claude's role in drafting releases
@@ -63,9 +63,10 @@ GitHub Releases trigger automatic Zenodo snapshots with permanent DOIs. `RELEASE
 When Tim says it's time for a release, Claude will:
 1. Read `RELEASES.md` and the merged PR history since the last release
 2. Draft the `RELEASES.md` entry for the new version
-3. Draft the full GitHub Release body (title, description, changelog) ready to paste into GitHub
-4. Open a PR with the `RELEASES.md` update
-5. After merge, provide the exact GitHub Release body for Tim to paste
+3. Open a PR with the `RELEASES.md` update
+4. After merge, draft the full GitHub Release body and present it to Tim
+5. **Wait for explicit approval before executing** - do not run `gh release create` until Tim confirms the language
+6. On approval, run `gh release create` with `--notes-file` automatically - no further prompting needed
 
 ### RELEASES.md entry format
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 *Plain-language introduction, illustrated companions, and reading paths for all audiences.*
 
-[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham)
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20060861.svg)](https://doi.org/10.5281/zenodo.20060861)
 
 For the formal framework index, Lean verification, and complete question register, see [README.md](README.md).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 *A formal mathematical proof that the emergence of something from nothing is not a starting assumption — it can be derived.*
 
-[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham)
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20060861.svg)](https://doi.org/10.5281/zenodo.20060861)
 
 For plain-language introduction, illustrated companions, and reading paths, see [GUIDE.md](GUIDE.md).
 


### PR DESCRIPTION
## Summary

Two additions following the v1.0 release and Zenodo setup.

**Zenodo DOI badge added to README.md and GUIDE.md:**
- DOI: 10.5281/zenodo.20060861
- Badge appears alongside the Lean CI and Sponsor badges on both pages

**CLAUDE.md release workflow updated:**
- Release execution now requires explicit approval from Tim before `gh release create` is run
- On approval, Claude executes the release directly via CLI - Tim does not need to do it manually
- Complete `gh release create` syntax documented including mandatory `<tag>`, `--target`, `--title`, and `--notes-file` arguments

## What did not change

No mathematical content, PDFs, or Lean proofs were modified.

## Test plan

- [x] Pre-push hook passed
- [x] Badge URL verified against Zenodo record

Generated with Claude Code
