### PR TITLE
fix: Zenodo DOI badge

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 *Plain-language introduction, illustrated companions, and reading paths for all audiences.*
 
-[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/1211147397.svg)](https://doi.org/10.5281/zenodo.20060861)
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/1211147397.svg)](https://doi.org/10.5281/zenodo.20060860)
 
 For the formal framework index, Lean verification, and complete question register, see [README.md](README.md).
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 *Plain-language introduction, illustrated companions, and reading paths for all audiences.*
 
-[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20060861.svg)](https://doi.org/10.5281/zenodo.20060861)
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/1211147397.svg)](https://doi.org/10.5281/zenodo.20060861)
 
 For the formal framework index, Lean verification, and complete question register, see [README.md](README.md).
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 *Plain-language introduction, illustrated companions, and reading paths for all audiences.*
 
-[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/1211147397.svg)](https://doi.org/10.5281/zenodo.20060860)
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20060860.svg)](https://doi.org/10.5281/zenodo.20060860)
 
 For the formal framework index, Lean verification, and complete question register, see [README.md](README.md).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 *A formal mathematical proof that the emergence of something from nothing is not a starting assumption — it can be derived.*
 
-[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/1211147397.svg)](https://doi.org/10.5281/zenodo.20060860)
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20060860.svg)](https://doi.org/10.5281/zenodo.20060860)
 
 For plain-language introduction, illustrated companions, and reading paths, see [GUIDE.md](GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 *A formal mathematical proof that the emergence of something from nothing is not a starting assumption — it can be derived.*
 
-[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/1211147397.svg)](https://doi.org/10.5281/zenodo.20060861)
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/1211147397.svg)](https://doi.org/10.5281/zenodo.20060860)
 
 For plain-language introduction, illustrated companions, and reading paths, see [GUIDE.md](GUIDE.md).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 *A formal mathematical proof that the emergence of something from nothing is not a starting assumption — it can be derived.*
 
-[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20060861.svg)](https://doi.org/10.5281/zenodo.20060861)
+[![Lean Action CI](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/timbrigham/ZeroParadox/actions/workflows/lean_action_ci.yml) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/timbrigham) [![DOI](https://zenodo.org/badge/1211147397.svg)](https://doi.org/10.5281/zenodo.20060861)
 
 For plain-language introduction, illustrated companions, and reading paths, see [GUIDE.md](GUIDE.md).
 


### PR DESCRIPTION
## Summary

Three-commit fix for the broken Zenodo DOI badge.

- **Commit 1:** Switched to Zenodo-provided badge image URL (1211147397.svg format)
- **Commit 2:** Corrected DOI digit — 10.5281/zenodo.20060860 (not .20060861)
- **Commit 3:** Switched to DOI-direct badge URL (DOI/10.5281/zenodo.20060860.svg) — confirmed working via live fetch; the latestdoi/{repo-id} endpoint returns 404

The badge now renders correctly in both README.md and GUIDE.md.

## What did not change

No mathematical content, PDFs, or Lean proofs were modified.

## Test plan

- [x] Fetched https://zenodo.org/badge/DOI/10.5281/zenodo.20060860.svg directly — returns valid SVG badge
- [x] DOI link https://doi.org/10.5281/zenodo.20060860 verified correct
