### PR TITLE
chore: lint cleanup — clean baseline (0 warnings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .claude-local/
 .claude/
 
+# Local MCP tooling (standalone repo, not part of the math publication)
+imap-email-mcp/
+
 # OS artifacts
 .DS_Store
 Thumbs.db

--- a/ZeroParadox/README.md
+++ b/ZeroParadox/README.md
@@ -12,6 +12,8 @@ lake build
 
 Clean build: zero errors, zero warnings across all files. Some files set `maxHeartbeats 400000` due to heavy import chains (p-adics + Hilbert space machinery).
 
+Lint policy: `weak.linter.mathlibStandardSet` is on, so the build flags genuine hygiene issues (unused variables, deprecated tactics, etc.). The pure Mathlib-*contribution* house-style linters (line length, `show`-for-readability, file-level `set_option`, duplicate namespace) are relaxed in `lakefile.toml` — they govern Mathlib PRs, not a standalone research repo. The `native_decide` linter stays on (it trusts the compiler, not just the kernel); no file currently uses `native_decide`.
+
 ## File Overview and Dependency Order
 
 ### Core chain

--- a/ZeroParadox/ZPJ_APG.lean
+++ b/ZeroParadox/ZPJ_APG.lean
@@ -279,7 +279,7 @@ theorem pureSelfLoop_decoration_unique
 theorem kCycle_node_eq_bot
     {V : Type*} [Quiver V]
     {U : Type*} [ZPSemilattice U] [ValuationStructure U] [DecorationUniverse U]
-    (d : V → U) (hd : IsDecoration d) (v : V) (k : ℕ) (hk : 0 < k)
+    (d : V → U) (_hd : IsDecoration d) (v : V) (k : ℕ) (hk : 0 < k)
     (hcycle : ValuationStructure.scale^[k] (d v) = d v) :
     d v = bot :=
   scale_iterate_unique_fp k hk (d v) hcycle
@@ -424,11 +424,14 @@ theorem acyclic_induction_step
 
     Requires [Fintype V] to bound the reachable set cardinality. -/
 
+-- `[Fintype V]` is not used in the *type* but is essential to the *proof*: it bounds the
+-- reachable-set cardinality so the strict-subset descent (`Set.ncard_lt_ncard`) terminates.
+set_option linter.unusedFintypeInType false in
 /-- Global decoration uniqueness: any two valid decorations of a finite APG are equal. -/
 theorem decoration_unique
     {V : Type*} [Quiver V] [Fintype V]
     {U : Type*} [ZPSemilattice U] [ValuationStructure U] [DecorationUniverse U]
-    (G : APG V) (d₁ d₂ : V → U) (hd₁ : IsDecoration d₁) (hd₂ : IsDecoration d₂) :
+    (_G : APG V) (d₁ d₂ : V → U) (hd₁ : IsDecoration d₁) (hd₂ : IsDecoration d₂) :
     d₁ = d₂ := by
   funext v
   suffices key : ∀ n : ℕ, ∀ u : V,

--- a/ZeroParadox/ZPJ_Model.lean
+++ b/ZeroParadox/ZPJ_Model.lean
@@ -66,7 +66,7 @@ noncomputable instance instNatInfZPS : ZPSemilattice ℕ∞ where
   join_assoc := min_assoc
   join_comm  := min_comm
   join_idem  := min_self
-  bot_join   := fun x => min_eq_right le_top
+  bot_join   := fun _ => min_eq_right le_top
 
 /-! ## § II. ValuationStructure Instance for ℕ∞ -/
 

--- a/ZeroParadox/ZPK.lean
+++ b/ZeroParadox/ZPK.lean
@@ -435,7 +435,7 @@ theorem isComputationalQuine_undecidable :
   -- Encoding: encode (φ c) ≠ 0 for all c
   have φ_enc : ∀ c : Code, Encodable.encode (φ c) ≠ 0 := by
     intro c heq
-    have h0 : Encodable.encode Code.zero = 0 := by native_decide
+    have h0 : Encodable.encode Code.zero = 0 := by decide
     have hne : φ c ≠ Code.zero := by simp [φ]
     exact hne (Encodable.encode_inj.mp (heq.trans h0.symm))
   -- IsComputationalQuine (φ c) ↔ ¬(eval c (encode c)).Dom
@@ -514,7 +514,7 @@ theorem infinite_quine_family :
     Set.infinite_range_of_injective hinj
   obtain ⟨k, hk⟩ : ∃ k : ℕ, n < Encodable.encode (Code.const k) := by
     by_contra h
-    push_neg at h
+    push Not at h
     apply hinf
     apply Set.Finite.subset (Finset.finite_toSet (Finset.range (n + 1)))
     intro x hx

--- a/ZeroParadox/ZPL.lean
+++ b/ZeroParadox/ZPL.lean
@@ -452,7 +452,7 @@ theorem snap_exactly_at_epsilon_zero
   · exact hfp epsilonZero epsilonZero_fixedPoint
   · intro α hα
     by_contra h
-    push_neg at h
+    push Not at h
     have hc0 : φ α = c₀ := snap_threshold_is_epsilon_zero φ hmono h0 α h
     rw [hc0] at hα
     exact absurd hα (by simp [c₀, c₁])
@@ -477,7 +477,7 @@ theorem kleene_ordinal_snap_bridge :
   · exact if_neg (lt_irrefl epsilonZero)
   · intro α hα
     by_contra h
-    push_neg at h
+    push Not at h
     simp only [if_pos h] at hα
     exact absurd hα (by simp [c₀, c₁])
 
@@ -539,7 +539,7 @@ theorem epsilon_zero_snap_canonical :
   · exact if_neg (lt_irrefl epsilonZero)
   · intro α hα
     by_contra h
-    push_neg at h
+    push Not at h
     simp only [if_pos h] at hα
     exact absurd hα (by simp [c₀, c₁])
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -8,6 +8,13 @@ pp.unicode.fun = true # pretty-prints `fun a ↦ b`
 relaxedAutoImplicit = false
 weak.linter.mathlibStandardSet = true
 maxSynthPendingDepth = 3
+# Standalone-repo lint policy: keep mathlibStandardSet on, but relax the pure
+# Mathlib-contribution house-style linters that don't fit a standalone research repo.
+# native_decide stays ON (soundness) and is exempted per-use via a scoped, documented disable.
+weak.linter.style.longLine = false    # the 100-char limit is Mathlib house style
+weak.linter.style.show = false        # `show` for readability is acceptable here
+weak.linter.style.setOption = false   # file-level maxHeartbeats is needed for heavy files
+weak.linter.dupNamespace = false      # e.g. ZeroParadox.APG.APG — harmless; rename would be invasive
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
## Lint cleanup — clean baseline before wheel / v3.0 work

A full `lake build` surfaced 54 latent `weak.linter.mathlibStandardSet` warnings (they only appear on a full rebuild; incremental builds hid them). This brings the build to **0 errors / 0 warnings (3350 jobs)** using the hybrid policy: fix genuine hygiene, relax pure Mathlib-contribution house-style linters, document the rest. Mathlib stays pinned at `v4.30.0-rc2` (unchanged).

### Relaxed (pure Mathlib house-style — `lakefile.toml`)
- `linter.style.longLine`, `linter.style.show`, `linter.style.setOption`, `linter.dupNamespace` → `false`. These govern Mathlib PR contributions, not a standalone research repo.

### Fixed (genuine hygiene)
- `push_neg` → `push Not` (deprecation) ×4 — ZPK, ZPL
- Unused variables renamed with `_` prefix ×3 — `ZPJ_Model` (`x`), `ZPJ_APG` (`hd`, `G`); none used in their proof bodies, call sites are positional

### Scoped exception ×1
- `decoration_unique` (`ZPJ_APG`): `set_option linter.unusedFintypeInType false in` with an inline comment — `[Fintype V]` drives the `Set.ncard_lt_ncard` strict-subset descent in the proof but does not appear in the type.

### Eliminated, not exempted
- The single `native_decide` (`ZPK`, `encode Code.zero = 0`) reduces fine with plain `decide`, so `native_decide` no longer appears anywhere in the repo.

### Docs / config
- `ZeroParadox/README.md` — the "zero warnings" line is now accurate; added a lint-policy paragraph.
- `.gitignore` — ignore the standalone `imap-email-mcp/` tooling folder (its own git repo, not part of the publication).

No `sorry` introduced; all Lean edits are status-neutral. Editorial and adversary review both passed for the prose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
